### PR TITLE
Fix Date Bug in I2B2 2006 Preprocessing

### DIFF
--- a/downstream_tasks/i2b2_preprocessing/i2b2_2006_deid/to_conll.py
+++ b/downstream_tasks/i2b2_preprocessing/i2b2_2006_deid/to_conll.py
@@ -16,8 +16,6 @@ with open(sys.argv[1]) as f:
         phi_tags = re.findall(regex, line)
         for tag in phi_tags:
             line = line.replace(tag[0], '__phi__').strip()
-
-
         # Walk through sentence
         phi_ind = 0
         for w in line.split():
@@ -29,8 +27,30 @@ with open(sys.argv[1]) as f:
                 for t in toks[1:]:
                     print(t, 'I-%s'%tag)
                 phi_ind += 1
+            # Two elif statements check for edge cases with Dates
+            elif w.startswith('__phi__'):
+                # examples like following format:
+                # <PHI TYPE="DATE">01/01</PHI>/1995 or <PHI TYPE="DATE">01-01</PHI>-95
+                phi = phi_tags[phi_ind]
+                tag = phi[1]
+                toks = phi[2].split()
+                print(toks[0], 'B-%s'%tag)
+                if w[7:8] == '/' or w[7:8] == '-':
+                    print(w[8:], 'O') # remove the / or - in the year
+                else:
+                    print(w[7:], 'O')
+                phi_ind += 1
+            elif w.endswith('__phi__'):
+                # 1995<PHI TYPE="DATE">0101</PHI>
+                phi = phi_tags[phi_ind]
+                tag = phi[1]
+                toks = phi[2].split()
+                print(w[:-7], 'O')
+                print(toks[0], 'B-%s'%tag)
+                phi_ind += 1
             else:
                 print(w, 'O')
         print()
+        i+=1
 
 

--- a/downstream_tasks/i2b2_preprocessing/i2b2_2006_deid/to_conll.py
+++ b/downstream_tasks/i2b2_preprocessing/i2b2_2006_deid/to_conll.py
@@ -16,6 +16,7 @@ with open(sys.argv[1]) as f:
         phi_tags = re.findall(regex, line)
         for tag in phi_tags:
             line = line.replace(tag[0], '__phi__').strip()
+
         # Walk through sentence
         phi_ind = 0
         for w in line.split():


### PR DESCRIPTION
In [`to_conll.py`](https://github.com/EmilyAlsentzer/clinicalBERT/blob/master/downstream_tasks/i2b2_preprocessing/i2b2_2006_deid/to_conll.py) processing code for I2B2 2006 DEID data, many Date examples are discarded and cast as 'O' instead of 'B-DATE' and still contain `__phi__` as tokens in the processed tsv files. In the `deid_surrogate_train_all_version2.xml` file, there were 5167 total `TYPE="DATE"` markers, but in the processed train.tsv I got after running `to_conll.py`, 3035 of these examples became cast as 'O' and had the `__phi__` token.

I believe the script fails when there's a PHI XML object with test before or after it, but no space. Broadly, these two types of cases:

1. `<PHI TYPE="DATE">01/01</PHI>/1995 or <PHI TYPE="DATE">01-01</PHI>-95`
2. `1995<PHI TYPE="DATE">0101</PHI>`

Updated `to_conll.py` script checks for these cases and splits them accordingly
	1. 01/01 B-DATE
	   1995 O
	2. 1995 O
            0101 B-DATE